### PR TITLE
Use Dictionary For ID Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The CLI I use to manage my notes / personal knowledge management
   formatting text to a preferred line length
 - [cSpell](https://github.com/streetsidesoftware/vscode-spell-checker) for spell
   checking within markdown files
+- [TODO Highlight](https://github.com/wayou/vscode-todo-highlight) to highlight
+  `todo-` annotations within markdown files, as I use this as a placeholder when
+  needing to create additional notes
 
 ## Schema
 

--- a/internal/language/random.go
+++ b/internal/language/random.go
@@ -21,7 +21,7 @@ type generatorFunc func(int) (string, error)
 // e.g. "ohylwsib-ttgfjwlj-hwqbxlyj-owyrlces".
 func RandomPhrase(dictionary []string, size int) (string, error) {
 	gf := generatePhrase(dictionary)
-	if dictionary != nil {
+	if dictionary == nil {
 		gf = generateString
 	}
 


### PR DESCRIPTION
- Bug where `generateString` was being used instead of `generatePhrase` even though there was a valid dictionary available 